### PR TITLE
fix: QNN bugs, performance improvements, and code cleanup

### DIFF
--- a/quri_parts_scaluq/circuit/__init__.py
+++ b/quri_parts_scaluq/circuit/__init__.py
@@ -11,8 +11,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from functools import lru_cache
 from typing import TYPE_CHECKING, Callable, Union, cast
+import threading
 import numpy as np
 from numpy.typing import ArrayLike
 from typing_extensions import assert_never
@@ -212,13 +212,24 @@ def convert_circuit(circuit: ImmutableQuantumCircuit) -> _backend.Circuit:
     return scaluq_circuit
 
 
-@lru_cache(maxsize=None)
+_convert_cache: dict[
+    int, tuple[ScaluqCircuit, Callable[[Sequence[float]], dict[str, list[float]]]]
+] = {}
+_convert_cache_lock = threading.Lock()
+
+
 def convert_parametric_circuit(
     circuit: ParametricQuantumCircuitProtocol,
 ) -> tuple[
     ScaluqCircuit,
     Callable[[Sequence[float]], dict[str, list[float]]],
 ]:
+    circuit_id = id(circuit)
+    with _convert_cache_lock:
+        cached = _convert_cache.get(circuit_id)
+        if cached is not None:
+            return cached
+
     param_circuit: ImmutableParametricQuantumCircuit
     param_mapper: Callable[[Sequence[float]], dict[str, list[float]]]
     if isinstance(circuit, ImmutableLinearMappedParametricQuantumCircuit):
@@ -279,4 +290,7 @@ def convert_parametric_circuit(
         else:
             scaluq_circuit.add_gate(convert_gate(gate))
 
-    return scaluq_circuit, param_mapper
+    result = (scaluq_circuit, param_mapper)
+    with _convert_cache_lock:
+        _convert_cache[circuit_id] = result
+    return result

--- a/quri_parts_scaluq/circuit/__init__.py
+++ b/quri_parts_scaluq/circuit/__init__.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from functools import lru_cache
 from typing import TYPE_CHECKING, Callable, Union, cast
 import numpy as np
 from numpy.typing import ArrayLike
@@ -211,6 +212,7 @@ def convert_circuit(circuit: ImmutableQuantumCircuit) -> _backend.Circuit:
     return scaluq_circuit
 
 
+@lru_cache(maxsize=None)
 def convert_parametric_circuit(
     circuit: ParametricQuantumCircuitProtocol,
 ) -> tuple[

--- a/quri_parts_scaluq/circuit/__init__.py
+++ b/quri_parts_scaluq/circuit/__init__.py
@@ -212,9 +212,18 @@ def convert_circuit(circuit: ImmutableQuantumCircuit) -> _backend.Circuit:
     return scaluq_circuit
 
 
-_convert_cache: dict[
-    int, tuple[ScaluqCircuit, Callable[[Sequence[float]], dict[str, list[float]]]]
-] = {}
+# Single-entry cache: stores the most recently converted circuit only.
+# A strong reference to the circuit is retained so its id() cannot be reused
+# by a different object while the cache is live, which would otherwise cause
+# id-collision false hits with an id-keyed dict cache.
+_convert_cache_last: (
+    tuple[
+        ParametricQuantumCircuitProtocol,
+        ScaluqCircuit,
+        Callable[[Sequence[float]], dict[str, list[float]]],
+    ]
+    | None
+) = None
 _convert_cache_lock = threading.Lock()
 
 
@@ -224,11 +233,10 @@ def convert_parametric_circuit(
     ScaluqCircuit,
     Callable[[Sequence[float]], dict[str, list[float]]],
 ]:
-    circuit_id = id(circuit)
+    global _convert_cache_last
     with _convert_cache_lock:
-        cached = _convert_cache.get(circuit_id)
-        if cached is not None:
-            return cached
+        if _convert_cache_last is not None and _convert_cache_last[0] is circuit:
+            return _convert_cache_last[1], _convert_cache_last[2]
 
     param_circuit: ImmutableParametricQuantumCircuit
     param_mapper: Callable[[Sequence[float]], dict[str, list[float]]]
@@ -290,7 +298,6 @@ def convert_parametric_circuit(
         else:
             scaluq_circuit.add_gate(convert_gate(gate))
 
-    result = (scaluq_circuit, param_mapper)
     with _convert_cache_lock:
-        _convert_cache[circuit_id] = result
-    return result
+        _convert_cache_last = (circuit, scaluq_circuit, param_mapper)
+    return scaluq_circuit, param_mapper

--- a/quri_parts_scaluq/estimator.py
+++ b/quri_parts_scaluq/estimator.py
@@ -226,10 +226,11 @@ def estimate_numerical_gradient(
     for op_idx, op in enumerate(operators):
         scaluq_op = convert_operator(op, n_qubits)
         exps = scaluq_op.get_expectation_value(state)
-        for s in range(n_samples):
-            for j in range(n_learning_params):
-                plus_idx = s * 2 * n_learning_params + 2 * j
-                minus_idx = plus_idx + 1
-                grads[s, op_idx, j] = (exps[plus_idx].real - exps[minus_idx].real) / delta
+        exps_real = np.fromiter((e.real for e in exps), dtype=np.float64, count=total_batch)
+        plus_vals = exps_real[0::2]
+        minus_vals = exps_real[1::2]
+        grads[:, op_idx, :] = ((plus_vals - minus_vals) / delta).reshape(
+            n_samples, n_learning_params
+        )
 
     return grads

--- a/scikit_quri/backend/oqtopus_estimator.py
+++ b/scikit_quri/backend/oqtopus_estimator.py
@@ -66,7 +66,7 @@ class OqtopusEstimator(BaseEstimator):
 
         if num_ops > 1 and num_states > 1 and num_ops != num_states:
             raise ValueError(
-                f"Number of operators ({num_ops}) does not matchnumber of states ({num_states}).",
+                f"Number of operators ({num_ops}) does not match number of states ({num_states}).",
             )
 
         if num_states == 1:

--- a/scikit_quri/backend/oqtopus_gradient_estimator.py
+++ b/scikit_quri/backend/oqtopus_gradient_estimator.py
@@ -28,19 +28,21 @@ class LearningCircuitParameter:
 
 
 def _parametric_estimate(
-    op_state: tuple[Estimatable, LearningCircuit], params: Sequence[LearningCircuitParameter]
+    op_state: tuple[Estimatable, LearningCircuit],
+    params: Sequence[LearningCircuitParameter],
+    estimator: OqtopusEstimator,
 ) -> Sequence[Estimate[complex]]:
     """複数のパラメータセットに対して期待値を一括計算する。
 
     Args:
         op_state: (演算子, 学習回路)のタプル。
         params: パラメータセットのシーケンス。
+        estimator: 期待値計算に使用する推定器。
 
     Returns:
         各パラメータセットに対する期待値のEstimateオブジェクトのシーケンス。
     """
     operator, circuit = op_state
-    estimator = OqtopusEstimator("qulacs")
     n_qubits = circuit.n_qubits
     estimates = []
     states = []
@@ -57,6 +59,7 @@ def numerical_gradient_estimates(
     circuit: LearningCircuit,
     params: LearningCircuitParameter,
     delta: float,
+    estimator: OqtopusEstimator,
 ) -> Sequence[complex]:
     """数値微分により勾配を計算する。
 
@@ -81,7 +84,7 @@ def numerical_gradient_estimates(
         current_learning_param = params.learning_param.copy()
         current_learning_param[i] -= delta * 0.5
         v.append(LearningCircuitParameter(input_param, current_learning_param))
-    estimates = _parametric_estimate((op, circuit), v)
+    estimates = _parametric_estimate((op, circuit), v, estimator)
     grad = []
     for i in range(len(params.learning_param)):
         d = estimates[2 * i].value - estimates[2 * i + 1].value
@@ -129,6 +132,9 @@ class OqtopusGradientEstimator(BaseGradientEstimator):
     OqtopusEstimatorを内部で使用し、数値微分により勾配を計算する。
     """
 
+    def __init__(self) -> None:
+        self.estimator = OqtopusEstimator("qulacs")
+
     def estimate_gradient(self, operators, state, params):
         """全パラメータに対する勾配を計算する。
 
@@ -158,6 +164,6 @@ class OqtopusGradientEstimator(BaseGradientEstimator):
             learning_param=np.array([params[i] for i in circuit.get_learning_params_indexes()]),
         )
         estimate_gradients = numerical_gradient_estimates(
-            operators, circuit, learning_params, delta=1e-5
+            operators, circuit, learning_params, delta=1e-5, estimator=self.estimator
         )
         return estimate_gradients

--- a/scikit_quri/backend/sim_estimator.py
+++ b/scikit_quri/backend/sim_estimator.py
@@ -23,10 +23,10 @@ class SimEstimator(BaseEstimator):
 
     def __init__(self, use_scaluq: bool = False) -> None:
         self.use_scaluq = use_scaluq
+        self._concurrent_estimator = create_qulacs_vector_concurrent_estimator()
 
     def estimate(self, operators, states):
-        estimator = create_qulacs_vector_concurrent_estimator()
-        return estimator(operators, states)
+        return self._concurrent_estimator(operators, states)
 
     def estimate_scaluq_batched(
         self,

--- a/scikit_quri/backend/sim_gradient_estimator.py
+++ b/scikit_quri/backend/sim_gradient_estimator.py
@@ -33,18 +33,18 @@ class SimGradientEstimator(BaseGradientEstimator):
             raise ValueError(f"Invalid method: {method}. Supported methods are {get_args(METHOD)}")
         self.method = method
         self.delta = delta
+        if method == "numerical":
+            self.estimator = create_numerical_gradient_estimator(
+                create_qulacs_vector_concurrent_parametric_estimator(), delta=self.delta
+            )
+        else:
+            self.estimator = create_parameter_shift_gradient_estimator(
+                create_qulacs_vector_concurrent_parametric_estimator()
+            )
 
     def estimate_gradient(
         self, operators: Estimatable, state: _ParametricStateT, params: Sequence[float]
     ) -> Estimates[complex]:
-        if self.method == "numerical":
-            self.estimator = create_numerical_gradient_estimator(
-                create_qulacs_vector_concurrent_parametric_estimator(), delta=self.delta
-            )
-        elif self.method == "parameter_shift":
-            self.estimator = create_parameter_shift_gradient_estimator(
-                create_qulacs_vector_concurrent_parametric_estimator()
-            )
         return self.estimator(operators, state, params)
 
     def estimate_learning_param_gradient(

--- a/scikit_quri/circuit/circuit.py
+++ b/scikit_quri/circuit/circuit.py
@@ -479,6 +479,27 @@ class LearningCircuit:
             pos.append(param.positions_in_circuit[0].gate_pos)
         return pos
 
+    def get_learning_param_grad_aggregators(self) -> List[List[Tuple[int, float]]]:
+        """Return aggregation info for computing parameter-shift gradients.
+
+        Each learnable parameter may occupy multiple circuit-level gate positions
+        when ``share_with`` is used. This method returns, for each parameter, the
+        list of ``(gate_pos, coef)`` tuples that must be summed with their
+        respective coefficients to obtain the total gradient w.r.t. that parameter.
+
+        Returns:
+            List of length ``learning_params_count``, where element ``[j]`` is a
+            list of ``(gate_pos, coef)`` tuples for the j-th learnable parameter.
+        """
+        aggregators: List[List[Tuple[int, float]]] = []
+        for param in self._learning_parameter_list:
+            param_aggs: List[Tuple[int, float]] = []
+            for pos in param.positions_in_circuit:
+                coef = pos.coef if pos.coef is not None else 1.0
+                param_aggs.append((pos.gate_pos, coef))
+            aggregators.append(param_aggs)
+        return aggregators
+
     def get_input_params_indexes(self) -> List[int]:
         """Return circuit-level indices of all input-data-driven parameter slots.
 
@@ -547,7 +568,7 @@ class LearningCircuit:
 
         return bound_parameters
 
-    def backprop_innner_product(
+    def backprop_inner_product(
         self, x: NDArray[np.float64], theta: NDArray[np.float64], state: QulacsQuantumState
     ) -> NDArray[np.float64]:
         """Compute gradients of learnable parameters via qulacs backpropagation using inner product.
@@ -879,11 +900,6 @@ class LearningCircuit:
                     shifted_params[base + 2 * j + 1, pos.gate_pos] -= shift
 
         return self.circuit, shifted_params
-
-
-def preprocess_x(x: NDArray[np.float64], i: int) -> float:
-    a: float = x[i % len(x)]
-    return a
 
 
 if __name__ == "__main__":

--- a/scikit_quri/circuit/circuit.py
+++ b/scikit_quri/circuit/circuit.py
@@ -141,6 +141,12 @@ class LearningCircuit:
 
     def __post_init__(self) -> None:
         self.circuit = UnboundParametricQuantumCircuit(self.n_qubits)
+        # Cache for the learning-only portion of bound_parameters.
+        # During fit, `parameters` is identical across all samples in a batch, so we
+        # rebuild this template only when `parameters` changes; per-sample calls only
+        # overwrite the input slots.
+        self._learning_template_params: Optional[NDArray[np.float64]] = None
+        self._learning_template: Optional[NDArray[np.float64]] = None
 
     def _new_parameter_position(self) -> int:
         """
@@ -539,18 +545,33 @@ class LearningCircuit:
             Sequence of float values with length ``parameter_count``, ready to pass to
             ``circuit.bind_parameters()``.
         """
-        bound_parameters = [0.0 for _ in range(self.parameter_count)]
-        # Learning parameters
-        for param in self._learning_parameter_list:
-            param_value = parameters[param.parameter_id]
-            param.value = param_value
-            for pos in param.positions_in_circuit:
-                coef = pos.coef if pos.coef is not None else 1.0
-                bound_parameters[pos.gate_pos] = param_value * coef
-        # Input parameters
+        # Build / refresh the learning-parameter template when *parameters* changes.
+        # During fitting, *parameters* is identical across all samples in a batch,
+        # so we only need to rebuild the template once per batch.
+        if (
+            self._learning_template is None
+            or self._learning_template_params is None
+            or not np.array_equal(self._learning_template_params, parameters)
+        ):
+            template = np.zeros(self.parameter_count)
+            for param in self._learning_parameter_list:
+                param_value = parameters[param.parameter_id]
+                param.value = param_value
+                for pos in param.positions_in_circuit:
+                    coef = pos.coef if pos.coef is not None else 1.0
+                    template[pos.gate_pos] = param_value * coef
+            self._learning_template = template
+            self._learning_template_params = parameters.copy()
+        else:
+            # Template is current; still update param.value for downstream
+            # consumers (e.g. parametric-input gates) that read theta.value.
+            for param in self._learning_parameter_list:
+                param.value = parameters[param.parameter_id]
+
+        bound_parameters = self._learning_template.copy()
+
+        # Input parameters — always recomputed because they depend on x.
         for param in self._input_parameter_list:
-            # Input parameter is resolved here (not in update_parameters),
-            # because its value depends on the input data `x`.
             angle = 0.0
             # Exactly one branch is taken depending on whether func needs a learning parameter
             if need_learning_parameter_guard(param.func, param.companion_parameter_id):
@@ -878,7 +899,6 @@ class LearningCircuit:
         """
         n_samples = len(data)
         n_learning = self.learning_params_count
-        total = n_samples * 2 * n_learning
 
         # Build base params once via to_batched: (n_samples, parameter_count)
         _, base_params = self.to_batched(data, parameters)
@@ -887,17 +907,32 @@ class LearningCircuit:
         # base_params[s] -> shifted_params[s*2*n_learning .. (s+1)*2*n_learning - 1]
         shifted_params = np.repeat(base_params, 2 * n_learning, axis=0)
 
-        # Build shift vectors: for each learning param j, get its circuit positions and coefs
+        # The shift pattern is identical across samples: for each learning param j, the
+        # plus row sits at offset 2*j and the minus row at 2*j+1 within each sample's
+        # 2*n_learning-row block. Build per-sample row offsets once and broadcast.
         half_delta = delta / 2
+        sample_offsets = np.arange(n_samples, dtype=np.int64) * (2 * n_learning)
         for j, lp in enumerate(self._learning_parameter_list):
-            for pos in lp.positions_in_circuit:
-                coef = pos.coef if pos.coef is not None else 1.0
-                shift = half_delta * coef
-                # Apply +shift to plus rows, -shift to minus rows for all samples
-                for s in range(n_samples):
-                    base = s * 2 * n_learning
-                    shifted_params[base + 2 * j, pos.gate_pos] += shift
-                    shifted_params[base + 2 * j + 1, pos.gate_pos] -= shift
+            plus_rows = sample_offsets + 2 * j
+            minus_rows = plus_rows + 1
+
+            # Fancy indexing: extract all gate positions and coefficients for this
+            # learning parameter into arrays, then update all samples and all
+            # positions simultaneously via np.add.at with broadcasted indices.
+            gate_positions = np.array([p.gate_pos for p in lp.positions_in_circuit], dtype=np.int64)
+            coefs = np.array(
+                [p.coef if p.coef is not None else 1.0 for p in lp.positions_in_circuit],
+                dtype=np.float64,
+            )
+            shifts = half_delta * coefs
+            # Broadcast shapes: (n_samples, 1) @ (1, n_positions) + (1, n_positions)
+            # -> adds shifts[k] at (plus_rows[i], gate_positions[k]) for all i,k
+            np.add.at(
+                shifted_params, (plus_rows[:, None], gate_positions[None, :]), shifts[None, :]
+            )
+            np.add.at(
+                shifted_params, (minus_rows[:, None], gate_positions[None, :]), -shifts[None, :]
+            )
 
         return self.circuit, shifted_params
 

--- a/scikit_quri/circuit/pre_defined.py
+++ b/scikit_quri/circuit/pre_defined.py
@@ -46,11 +46,9 @@ def create_qcl_ansatz(
             lambda x, i=i: np.arccos(preprocess_x(x, i) * preprocess_x(x, i)),
         )
 
-    # time_evol_gate = _create_time_evol_gate(n_qubit, time_step)
     time_evol_circuit = _create_time_evol_circuit(n_qubit, time_step, seed=seed)
     for _ in range(c_depth):
         circuit.circuit += time_evol_circuit
-        # circuit.add_gate(time_evol_gate)
         for i in range(n_qubit):
             circuit.add_parametric_RX_gate(i)
             circuit.add_parametric_RZ_gate(i)
@@ -91,60 +89,6 @@ def _create_time_evol_circuit(
             )
             circuit.add_CNOT_gate(i, j)
     return circuit
-
-
-def _create_time_evol_gate(
-    n_qubit,
-    time_step=0.77,
-    rng: Optional[Generator] = None,
-    seed: Optional[int] = 0,
-) -> QuantumGate:
-    """Create a hamiltonian dynamics with transverse field ising model with random interaction and random magnetic field
-
-    Args:
-        n_qubit: number of qubits
-        time_step: evolution time
-        rng: random number generator
-        seed: seed for random number
-    Return:
-        qulacs' gate object
-
-    """
-    if rng is None:
-        rng = default_rng(seed)
-
-    ham = _make_hamiltonian(n_qubit, rng)
-    # Create time evolution operator by diagonalization.
-    # H*P = P*D <-> H = P*D*P^dagger
-    diag, eigen_vecs = np.linalg.eigh(ham)
-    time_evol_op = np.dot(
-        np.dot(eigen_vecs, np.diag(np.exp(-1j * time_step * diag))),
-        eigen_vecs.T.conj(),
-    )  # e^-iHT
-
-    # Convert to a qulacs gate
-    time_evol_gate = QuantumGate(
-        name="UnitaryMatrix",
-        target_indices=[i for i in range(n_qubit)],
-        unitary_matrix=time_evol_op,
-    )
-
-    return time_evol_gate
-
-
-def _make_hamiltonian(n_qubit, rng: Optional[Generator] = None, seed: Optional[int] = 0):
-    if rng is None:
-        rng = default_rng(seed)
-    X_mat = np.array([[0, 1], [1, 0]])
-    Z_mat = np.array([[1, 0], [0, -1]])
-    ham = np.zeros((2**n_qubit, 2**n_qubit), dtype=complex)
-    for i in range(n_qubit):
-        Jx = rng.uniform(-1.0, 1.0)
-        ham += Jx * _make_fullgate([[i, X_mat]], n_qubit)
-        for j in range(i + 1, n_qubit):
-            J_ij = rng.uniform(-1.0, 1.0)
-            ham += J_ij * _make_fullgate([[i, Z_mat], [j, Z_mat]], n_qubit)
-    return ham
 
 
 def _make_fullgate(list_SiteAndOperator, n_qubit):
@@ -220,7 +164,7 @@ def create_ibm_embedding_circuit(n_qubit: int) -> LearningCircuit:
         circuit.add_CNOT_gate(i, j)
         circuit.add_input_RZ_gate(
             j,
-            lambda x, i=i: (np.pi - preprocess_x(x, i) * (np.pi - preprocess_x(x, j))),
+            lambda x, i=i, j=j: (np.pi - preprocess_x(x, i) * (np.pi - preprocess_x(x, j))),
         )
         circuit.add_CNOT_gate(i, j)
     for i in range(n_qubit):
@@ -231,7 +175,7 @@ def create_ibm_embedding_circuit(n_qubit: int) -> LearningCircuit:
         circuit.add_CNOT_gate(i, j)
         circuit.add_input_RZ_gate(
             j,
-            lambda x, i=i: (np.pi - preprocess_x(x, i) * (np.pi - preprocess_x(x, j))),
+            lambda x, i=i, j=j: (np.pi - preprocess_x(x, i) * (np.pi - preprocess_x(x, j))),
         )
         circuit.add_CNOT_gate(i, j)
     return circuit

--- a/scikit_quri/circuit/pre_defined.py
+++ b/scikit_quri/circuit/pre_defined.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import numpy as np
 from numpy.random import Generator, default_rng
 from numpy.typing import NDArray
-from quri_parts.circuit import CNOT, CZ, QuantumCircuit, QuantumGate
+from quri_parts.circuit import CNOT, CZ, QuantumCircuit
 
 from .circuit import LearningCircuit
 

--- a/scikit_quri/qkrr/qkrr.py
+++ b/scikit_quri/qkrr/qkrr.py
@@ -11,7 +11,7 @@ from sklearn.model_selection import RandomizedSearchCV
 
 
 from scikit_quri.circuit import LearningCircuit
-from scikit_quri.state.overlap_estimator import overlap_estimator
+from scikit_quri.state.overlap_estimator import OverlapEstimator
 
 
 class QKRR:
@@ -40,7 +40,7 @@ class QKRR:
         for i in range(len(x)):
             self.data_circuits.append(self._run_circuit(x[i]))
 
-        self.estimator = overlap_estimator(sampler)
+        self.estimator = OverlapEstimator(sampler)
         kar = self.estimator.estimate_concurrent(self.data_circuits, self.data_circuits).reshape(
             len(x), len(x)
         )
@@ -49,7 +49,7 @@ class QKRR:
         # hyperparameter tuning
         alpha_low = 1e-3
         alpha_high = 1e2
-        n_iteration = 5
+        n_iteration = self.n_iteration
         random_state = 0
         param_distributions = {
             "alpha": loguniform(

--- a/scikit_quri/qnn/_qnn_common.py
+++ b/scikit_quri/qnn/_qnn_common.py
@@ -134,8 +134,13 @@ def predict_inner_cached(
 
     During optimization ``cost_func`` and ``grad_func`` are called back-to-back
     with the same parameters. This cache avoids running the circuit twice per
-    step by storing the most recent result keyed on ``cached_params`` (compared
-    with ``np.array_equal``) and ``cached_x_id`` (``id()`` of the input array).
+    step by storing the most recent result keyed on the params content and a
+    composite x_scaled fingerprint.
+
+    The x fingerprint combines ``id(x_scaled)`` with ``shape`` and ``dtype`` to
+    guard against the case where the previously cached array was garbage
+    collected and a new array reuses the same memory address. A params hash is
+    used as a fast-fail check before the exact ``np.array_equal`` comparison.
 
     Args:
         ansatz: Learning circuit.
@@ -145,20 +150,24 @@ def predict_inner_cached(
         params: Learning parameters.
         y_exp_ratio: Scaling factor applied to expectation values.
         cache: Mutable dict with keys ``cached_params`` (Optional[NDArray]),
-            ``y_pred`` (Optional[NDArray]), ``cached_x_id`` (Optional[int]).
+            ``y_pred`` (Optional[NDArray]), ``cached_x_fp`` (Optional[tuple]),
+            ``cached_params_hash`` (Optional[int]).
 
     Returns:
         Prediction matrix. Shape: (n_samples, n_operators).
     """
-    params_arr = np.asarray(params)
-    x_id = id(x_scaled)
+    params_arr = np.ascontiguousarray(np.asarray(params))
+    x_fp = (id(x_scaled), x_scaled.shape, x_scaled.dtype)
+    params_hash = hash(params_arr.tobytes())
     cached_params: NDArray[np.float64] | None = cache.get("cached_params")
     cached_y_pred: NDArray[np.float64] | None = cache.get("y_pred")
-    cached_x_id: int | None = cache.get("cached_x_id")
+    cached_x_fp: tuple | None = cache.get("cached_x_fp")
+    cached_params_hash: int | None = cache.get("cached_params_hash")
     if (
         cached_params is not None
         and cached_y_pred is not None
-        and cached_x_id == x_id
+        and cached_x_fp == x_fp
+        and cached_params_hash == params_hash
         and cached_params.shape == params_arr.shape
         and np.array_equal(cached_params, params_arr)
     ):
@@ -166,7 +175,8 @@ def predict_inner_cached(
     y_pred = predict_inner(ansatz, estimator, operators, x_scaled, params, y_exp_ratio)
     cache["cached_params"] = params_arr.copy()
     cache["y_pred"] = y_pred
-    cache["cached_x_id"] = x_id
+    cache["cached_x_fp"] = x_fp
+    cache["cached_params_hash"] = params_hash
     return y_pred
 
 

--- a/scikit_quri/qnn/_qnn_common.py
+++ b/scikit_quri/qnn/_qnn_common.py
@@ -118,7 +118,6 @@ def estimate_grad(
     operators: Sequence[Estimatable],
     x_scaled: NDArray[np.float64],
     params: Params,
-    learning_param_indexes: Sequence[int],
     estimator: BaseEstimator | None = None,
     delta: float = 1e-5,
 ) -> NDArray[np.float64]:
@@ -130,7 +129,6 @@ def estimate_grad(
         operators: List of measurement operators. Length: n_operators.
         x_scaled: Scaled input data. Shape: (n_samples, n_features).
         params: Learning parameters.
-        learning_param_indexes: Indices to extract learning parameters from full parameter vector.
         estimator: Optional estimator. If SimEstimator with use_scaluq=True, uses scaluq batched path.
         delta: Finite difference step size for scaluq numerical gradient.
 
@@ -151,14 +149,24 @@ def estimate_grad(
         )
 
     n_ops = len(operators)
-    n_learning_params = len(learning_param_indexes)
+    n_learning_params = ansatz.learning_params_count
     grads = []
+
+    # Build aggregation map from the circuit: for each learnable parameter,
+    # list of (gate_pos, coef) spanning all shared gate positions.
+    agg_map = ansatz.get_learning_param_grad_aggregators()
+
     for x in x_scaled:
         circuit_params = ansatz.generate_bound_params(x, params)
         param_state = quantum_state(n_qubits=ansatz.n_qubits, circuit=ansatz.circuit)
         grad = np.zeros((n_ops, n_learning_params), dtype=np.float64)
         for i, op in enumerate(operators):
             estimate = gradient_estimator(op, param_state, circuit_params)
-            grad[i, :] = np.array(estimate.values)[learning_param_indexes].real
+            values = np.array(estimate.values).real
+            for j, param_aggs in enumerate(agg_map):
+                total = 0.0
+                for gate_pos, coef in param_aggs:
+                    total += values[gate_pos] * coef
+                grad[i, j] = total
         grads.append(grad)
     return np.asarray(grads)

--- a/scikit_quri/qnn/_qnn_common.py
+++ b/scikit_quri/qnn/_qnn_common.py
@@ -121,6 +121,55 @@ def predict_inner(
     return compute_expectations(estimator, operators, circuit_states, y_exp_ratio)
 
 
+def predict_inner_cached(
+    ansatz: LearningCircuit,
+    estimator: BaseEstimator,
+    operators: Sequence[Estimatable],
+    x_scaled: NDArray[np.float64],
+    params: Params,
+    y_exp_ratio: float,
+    cache: dict,
+) -> NDArray[np.float64]:
+    """Compute predictions with caching of the last (params, x_scaled) pair.
+
+    During optimization ``cost_func`` and ``grad_func`` are called back-to-back
+    with the same parameters. This cache avoids running the circuit twice per
+    step by storing the most recent result keyed on ``cached_params`` (compared
+    with ``np.array_equal``) and ``cached_x_id`` (``id()`` of the input array).
+
+    Args:
+        ansatz: Learning circuit.
+        estimator: Expectation value estimator.
+        operators: List of measurement operators. Shape: (n_operators,).
+        x_scaled: Scaled input data. Shape: (n_samples, n_features).
+        params: Learning parameters.
+        y_exp_ratio: Scaling factor applied to expectation values.
+        cache: Mutable dict with keys ``cached_params`` (Optional[NDArray]),
+            ``y_pred`` (Optional[NDArray]), ``cached_x_id`` (Optional[int]).
+
+    Returns:
+        Prediction matrix. Shape: (n_samples, n_operators).
+    """
+    params_arr = np.asarray(params)
+    x_id = id(x_scaled)
+    cached_params: NDArray[np.float64] | None = cache.get("cached_params")
+    cached_y_pred: NDArray[np.float64] | None = cache.get("y_pred")
+    cached_x_id: int | None = cache.get("cached_x_id")
+    if (
+        cached_params is not None
+        and cached_y_pred is not None
+        and cached_x_id == x_id
+        and cached_params.shape == params_arr.shape
+        and np.array_equal(cached_params, params_arr)
+    ):
+        return cached_y_pred
+    y_pred = predict_inner(ansatz, estimator, operators, x_scaled, params, y_exp_ratio)
+    cache["cached_params"] = params_arr.copy()
+    cache["y_pred"] = y_pred
+    cache["cached_x_id"] = x_id
+    return y_pred
+
+
 def estimate_grad(
     ansatz: LearningCircuit,
     gradient_estimator: GradientEstimatorType,

--- a/scikit_quri/qnn/_qnn_common.py
+++ b/scikit_quri/qnn/_qnn_common.py
@@ -38,12 +38,14 @@ def build_circuit_states(
     Returns:
         List of bound quantum states, one per input sample. Length: n_samples.
     """
+    # Hoist parametric state construction out of the per-sample loop:
+    # the underlying circuit is identical across samples; only bound params change.
+    param_circuit_state: ParametricCircuitQuantumState = quantum_state(  # type: ignore
+        n_qubits=ansatz.n_qubits, circuit=ansatz.circuit
+    )
     circuit_states: List[QulacsStateT] = []
     for x in x_scaled:
         circuit_params = ansatz.generate_bound_params(x, params)
-        param_circuit_state: ParametricCircuitQuantumState = quantum_state(  # type: ignore
-            n_qubits=ansatz.n_qubits, circuit=ansatz.circuit
-        )
         circuit_state = param_circuit_state.bind_parameters(circuit_params)
         circuit_states.append(circuit_state)
     return circuit_states
@@ -68,10 +70,17 @@ def compute_expectations(
     """
     n_samples = len(circuit_states)
     n_ops = len(operators)
-    res = np.zeros((n_samples, n_ops), dtype=np.float64)
-    for i, op in enumerate(operators):
-        estimates = estimator.estimate([op], circuit_states)
-        res[:, i] = np.array([e.value.real for e in estimates])
+    operators_list = list(operators)
+    # Flatten to 1-to-1 (op, state) pairs in row-major order:
+    # pair index s*n_ops + i corresponds to (operators[i], circuit_states[s]).
+    # A single concurrent estimator call lets the backend parallelize across
+    # both axes instead of serializing across operators.
+    ops_flat = operators_list * n_samples
+    states_flat = [s for s in circuit_states for _ in range(n_ops)]
+    estimates = estimator.estimate(ops_flat, states_flat)
+    res = np.fromiter(
+        (e.value.real for e in estimates), dtype=np.float64, count=n_samples * n_ops
+    ).reshape(n_samples, n_ops)
     res *= y_exp_ratio
     return res
 
@@ -150,23 +159,34 @@ def estimate_grad(
 
     n_ops = len(operators)
     n_learning_params = ansatz.learning_params_count
-    grads = []
 
     # Build aggregation map from the circuit: for each learnable parameter,
     # list of (gate_pos, coef) spanning all shared gate positions.
     agg_map = ansatz.get_learning_param_grad_aggregators()
 
+    # Compact sparse aggregation matrix using only positions referenced by some
+    # learning parameter. Restricting to active positions avoids 0 * inf = NaN
+    # contamination when the gradient estimator returns non-finite values at
+    # input-only parameter slots (which the old per-element loop never touched).
+    active_positions = sorted({gp for aggs in agg_map for gp, _ in aggs})
+    pos_to_row = {p: i for i, p in enumerate(active_positions)}
+    n_active = len(active_positions)
+    A = np.zeros((n_active, n_learning_params), dtype=np.float64)
+    for j, param_aggs in enumerate(agg_map):
+        for gate_pos, coef in param_aggs:
+            A[pos_to_row[gate_pos], j] = coef
+    active_idx = np.asarray(active_positions, dtype=np.int64)
+
+    # Hoist parametric state construction out of the per-sample loop.
+    param_state = quantum_state(n_qubits=ansatz.n_qubits, circuit=ansatz.circuit)
+
+    grads = []
+    values_matrix = np.zeros((n_ops, n_active), dtype=np.float64)
     for x in x_scaled:
         circuit_params = ansatz.generate_bound_params(x, params)
-        param_state = quantum_state(n_qubits=ansatz.n_qubits, circuit=ansatz.circuit)
-        grad = np.zeros((n_ops, n_learning_params), dtype=np.float64)
         for i, op in enumerate(operators):
             estimate = gradient_estimator(op, param_state, circuit_params)
-            values = np.array(estimate.values).real
-            for j, param_aggs in enumerate(agg_map):
-                total = 0.0
-                for gate_pos, coef in param_aggs:
-                    total += values[gate_pos] * coef
-                grad[i, j] = total
-        grads.append(grad)
+            values = np.ascontiguousarray(np.asarray(estimate.values).real, dtype=np.float64)
+            values_matrix[i, :] = values[active_idx]
+        grads.append(np.einsum("ij,jk->ik", values_matrix, A))
     return np.asarray(grads)

--- a/scikit_quri/qnn/classifier.py
+++ b/scikit_quri/qnn/classifier.py
@@ -12,7 +12,11 @@ from sklearn.preprocessing import MinMaxScaler
 from sklearn.metrics import log_loss
 from quri_parts.core.operator import Operator, pauli_label
 
-from ._qnn_common import GradientEstimatorType, predict_inner, estimate_grad
+from ._qnn_common import (
+    GradientEstimatorType,
+    predict_inner_cached,
+    estimate_grad,
+)
 
 
 @dataclass
@@ -72,6 +76,7 @@ class QNNClassifier:
     trained_param: Optional[Params] = field(default=None)
 
     n_qubit: int = field(init=False)
+    _pred_cache: dict = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not issubclass(type(self.estimator), BaseEstimator):
@@ -171,13 +176,14 @@ class QNNClassifier:
     def _predict_inner(
         self, x_scaled: NDArray[np.float64], params: NDArray[np.float64]
     ) -> NDArray[np.float64]:
-        return predict_inner(
+        return predict_inner_cached(
             self.ansatz,
             self.estimator,
             self.operator,
             x_scaled,
             params,
             self.y_exp_ratio,
+            self._pred_cache,
         )
 
     def cost_func(

--- a/scikit_quri/qnn/classifier.py
+++ b/scikit_quri/qnn/classifier.py
@@ -65,11 +65,8 @@ class QNNClassifier:
     operator: List[Estimatable] = field(default_factory=list)
 
     x_norm_range: float = field(default=1.0)
-    y_norm_range: float = field(default=0.7)
 
     do_x_scale: bool = field(default=True)
-    do_y_scale: bool = field(default=True)
-    n_outputs: int = field(default=1)
     y_exp_ratio: float = field(default=2.2)
 
     trained_param: Optional[Params] = field(default=None)
@@ -80,32 +77,18 @@ class QNNClassifier:
         if not issubclass(type(self.estimator), BaseEstimator):
             raise TypeError("estimator must be a subclass of BaseEstimator")
         self.n_qubit = self.ansatz.n_qubits
+        if self.num_class > self.n_qubit:
+            raise ValueError(f"num_class ({self.num_class}) must be <= n_qubits ({self.n_qubit})")
         if self.do_x_scale:
             self.scale_x_scaler = MinMaxScaler(
                 feature_range=(-self.x_norm_range, self.x_norm_range)  # type: ignore
             )
 
-    def _softmax(self, x: NDArray[np.float64], axis=None) -> NDArray[np.float64]:
+    @staticmethod
+    def _softmax(x: NDArray[np.float64], axis=None) -> NDArray[np.float64]:
         x_max = np.amax(x, axis=axis, keepdims=True)
         exp_x_shifted = np.exp(x - x_max)
         return exp_x_shifted / np.sum(exp_x_shifted, axis=axis, keepdims=True)
-
-    def _cost(
-        self,
-        x_train: NDArray[np.float64],
-        y_train: NDArray[np.int64],
-        params: NDArray[np.float64],
-    ):
-        if x_train.ndim == 1:
-            x_train = x_train.reshape(-1, 1)
-
-        if self.do_x_scale:
-            x_scaled = self.scale_x_scaler.fit_transform(x_train)
-        else:
-            x_scaled = x_train
-
-        cost = self.cost_func(x_scaled, y_train, params)
-        return cost
 
     def fit(
         self,
@@ -154,7 +137,7 @@ class QNNClassifier:
         c = 0
         while maxiter > c:
             optimizer_state = self.optimizer.step(optimizer_state, cost_func, grad_func)
-            print("\r", f"iter:{c}/{maxiter} cost:{optimizer_state.cost=}", end="")
+            print(f"\riter:{c}/{maxiter} cost:{optimizer_state.cost=}", end="", flush=True)
 
             if optimizer_state.status == OptimizerStatus.CONVERGED:
                 break
@@ -214,34 +197,30 @@ class QNNClassifier:
     def cost_func_grad(
         self, x_scaled: NDArray[np.float64], y_train: NDArray[np.int64], params: Params
     ) -> NDArray[np.float64]:
-        # start = time.perf_counter()
         y_pred = self._predict_inner(x_scaled, params)
         y_pred_sm = self._softmax(y_pred, axis=1)
         raw_grads = self._estimate_grad(x_scaled, params)
-        # print(f"{raw_grads.shape=}")
-        grads = np.zeros(self.ansatz.learning_params_count)
-        # print(f"{grads.shape=}")
-        # print(f"{raw_grads=}")
-        for sample_index in range(len(x_scaled)):
-            for current_class in range(self.num_class):
-                expected = 1.0 if current_class == y_train[sample_index] else 0.0
-                coef = self.y_exp_ratio * (-expected + y_pred_sm[sample_index][current_class])
-                grads += coef * raw_grads[sample_index][current_class]
-        grads /= len(x_scaled)
-        # print(f"{time.perf_counter()-start=}")
+
+        # One-hot encode labels: y_one_hot[s, c] = 1 if c == y_train[s] else 0
+        y_one_hot = np.zeros((len(x_scaled), self.num_class), dtype=np.float64)
+        y_one_hot[np.arange(len(x_scaled)), y_train] = 1.0
+
+        # coef[s, c] = y_exp_ratio * (pred[s, c] - one_hot[s, c])
+        coef = self.y_exp_ratio * (y_pred_sm - y_one_hot)
+
+        # grads[p] = 1/N * sum_s sum_c coef[s,c] * raw_grads[s,c,p]
+        grads = np.einsum("sc,scp->p", coef, raw_grads) / len(x_scaled)
 
         return grads
 
     def _estimate_grad(
         self, x_scaled: NDArray[np.float64], params: NDArray[np.float64]
     ) -> NDArray[np.float64]:
-        learning_param_indexes = self.ansatz.get_minimum_learning_param_indexes()
         return estimate_grad(
             self.ansatz,
             self.gradient_estimator,
             self.operator,
             x_scaled,
             params,
-            learning_param_indexes,
             estimator=self.estimator,
         )

--- a/scikit_quri/qnn/classifier.py
+++ b/scikit_quri/qnn/classifier.py
@@ -7,7 +7,7 @@ from quri_parts.algo.optimizer import Optimizer, Params, OptimizerStatus
 from quri_parts.core.estimator import Estimatable
 from scikit_quri.circuit import LearningCircuit
 from scikit_quri.backend import BaseEstimator
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.metrics import log_loss
 from quri_parts.core.operator import Operator, pauli_label
@@ -76,7 +76,7 @@ class QNNClassifier:
     trained_param: Optional[Params] = field(default=None)
 
     n_qubit: int = field(init=False)
-    _pred_cache: dict = field(default_factory=dict)
+    _pred_cache: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not issubclass(type(self.estimator), BaseEstimator):
@@ -152,6 +152,9 @@ class QNNClassifier:
             c += 1
         print("")
         self.trained_param = optimizer_state.params
+        # Drop cached training-batch prediction so it doesn't pin the y_pred matrix
+        # for the remainder of the instance's lifetime.
+        self._pred_cache.clear()
 
     def predict(self, x_test: NDArray[np.float64]) -> NDArray[np.float64]:
         """Predict outcome for each input data in ``x_test``. This method returns the predicted outcome as a vector of probabilities for each class.

--- a/scikit_quri/qnn/generation.py
+++ b/scikit_quri/qnn/generation.py
@@ -42,6 +42,7 @@ class QNNGenerator:
         self.gauss_sigma = gauss_sigma
         self.fitting_qubit = fitting_qubit
         self.theta: None | List[float] = None
+        self.trained_param: None | List[float] = None
 
         self.observables = [pauli_label(f"Z{i}") for i in range(self.n_qubit)]
 
@@ -78,7 +79,10 @@ class QNNGenerator:
         self.trained_param = optimizer_state.params
 
     def predict(self) -> NDArray[np.float64]:
-        y_pred_in = evaluate_state_to_vector(self._predict_inner()).vector
+        if self.trained_param is None:
+            raise ValueError("run fit() before predict")
+
+        y_pred_in = evaluate_state_to_vector(self._predict_inner(self.trained_param)).vector
         y_pred_conj = y_pred_in.conjugate()
         data_per: NDArray[np.float64] = np.abs(y_pred_in * y_pred_conj)
 
@@ -91,11 +95,11 @@ class QNNGenerator:
         return data_per
 
     def _predict_and_inner(self) -> Tuple[NDArray[np.float64], QuantumState]:
-        state = self._predict_inner()
+        state = self._predict_inner(self.theta)
         y_pred_in = evaluate_state_to_vector(state).vector
         y_pred_conj = y_pred_in.conjugate()
 
-        data_per = y_pred_in * y_pred_conj
+        data_per = (y_pred_in * y_pred_conj).real
 
         if self.n_qubit != self.fitting_qubit:
             data_per = data_per.reshape(
@@ -104,8 +108,8 @@ class QNNGenerator:
             data_per = data_per.sum(axis=0)
         return (data_per, state)
 
-    def _predict_inner(self) -> QuantumState:
-        circuit = self.circuit.bind_input_and_parameters(np.array([0]), np.array(self.theta))
+    def _predict_inner(self, theta: List[float]) -> QuantumState:
+        circuit = self.circuit.bind_input_and_parameters(np.array([0]), np.array(theta))
         state = quantum_state(n_qubits=self.n_qubit, circuit=circuit)
         return state
 
@@ -148,7 +152,8 @@ class QNNGenerator:
         train_scaled: NDArray[np.float64],
     ) -> NDArray[np.float64]:
         self.theta = theta
-        data_diff = self.predict() - train_scaled
+        (pre, _) = self._predict_and_inner()
+        data_diff = pre - train_scaled
         conv_diff = self.conving(data_diff)
         cost = np.dot(data_diff, conv_diff)
         return cost
@@ -167,5 +172,5 @@ class QNNGenerator:
         state_vec = evaluate_state_to_vector(prein).vector
         ret = QulacsQuantumState(self.n_qubit)
         ret.load(convconv_diff * state_vec * 4)
-        grad = np.array(self.circuit.backprop_innner_product([0], self.theta, ret))
+        grad = np.array(self.circuit.backprop_inner_product([0], self.theta, ret))
         return -grad

--- a/scikit_quri/qnn/kernel_tsne.py
+++ b/scikit_quri/qnn/kernel_tsne.py
@@ -135,7 +135,6 @@ class TSNE:
         Returns:
             Symmetric joint probability matrix P of shape (n_samples, n_samples).
         """
-        n_data = len(X_train_state)
         estimator = overlap_estimator(X_train_state)
         # Materialize every qulacs state up front so the pairwise loop only does
         # inner products (was: pair-by-pair estimate() with per-call None checks).

--- a/scikit_quri/qnn/kernel_tsne.py
+++ b/scikit_quri/qnn/kernel_tsne.py
@@ -136,15 +136,18 @@ class TSNE:
             Symmetric joint probability matrix P of shape (n_samples, n_samples).
         """
         n_data = len(X_train_state)
-        sq_distance = np.zeros((n_data, n_data))
         estimator = overlap_estimator(X_train_state)
-        for i in range(n_data):
-            for j in range(i + 1, n_data):
-                inner_prod = estimator.estimate(i, j)
-                sq_distance[i][j] = 1 - inner_prod
-                sq_distance[j][i] = sq_distance[i][j]
-            print("\r", f"{i}/{n_data}", end="")
-        print()
+        # Materialize every qulacs state up front so the pairwise loop only does
+        # inner products (was: pair-by-pair estimate() with per-call None checks).
+        estimator.calc_all_qula_states()
+        # Stack all state vectors into a single matrix and compute the full Gram
+        # matrix in one BLAS call: |⟨φi|φj⟩|² = |conj(v_i) · v_j|².
+        vectors = np.stack([qs.get_vector() for qs in estimator.qula_states])
+        overlap_matrix = vectors.conj() @ vectors.T
+        fidelity = np.abs(overlap_matrix) ** 2
+        sq_distance = 1.0 - fidelity
+        # Diagonal must be zero: floating-point noise can leave it slightly off.
+        np.fill_diagonal(sq_distance, 0.0)
         p_probs = self.joint_probabilities(sq_distance, self.perplexity)
         return p_probs
 

--- a/scikit_quri/qnn/regressor.py
+++ b/scikit_quri/qnn/regressor.py
@@ -228,16 +228,10 @@ class QNNRegressor:
         # for MSE
         y_pred = self._predict_inner(x_scaled, params)
         y_pred_grads = self._estimate_grad(x_scaled, params)
-        grads = np.zeros(len(self.ansatz.get_learning_params_indexes()))
         diff = y_pred - y_scaled
-        for i in range(len(diff)):
-            # (self.n_outputs, params)
-            grad: np.ndarray = 2 * diff[i][:, np.newaxis] * y_pred_grads[i, :, :]
-            # (params)
-            grad = grad.mean(axis=0)
-            grads += grad
-        grads /= len(diff)
-
+        n_samples = len(diff)
+        # grads[p] = (1/N) * sum_s (1/n_outputs) * sum_o 2 * diff[s,o] * y_pred_grads[s,o,p]
+        grads = (2.0 / (n_samples * self.n_outputs)) * np.einsum("so,sop->p", diff, y_pred_grads)
         return grads
 
     def _estimate_grad(self, x_scaled: NDArray[np.float64], params: Params) -> NDArray[np.float64]:

--- a/scikit_quri/qnn/regressor.py
+++ b/scikit_quri/qnn/regressor.py
@@ -241,14 +241,12 @@ class QNNRegressor:
         return grads
 
     def _estimate_grad(self, x_scaled: NDArray[np.float64], params: Params) -> NDArray[np.float64]:
-        learning_params_indexes = self.ansatz.get_learning_params_indexes()
         return estimate_grad(
             self.ansatz,
             self.gradient_estimator,
             self.operator,
             x_scaled,
             params,
-            learning_params_indexes,
             estimator=self.estimator,
         )
 

--- a/scikit_quri/qnn/regressor.py
+++ b/scikit_quri/qnn/regressor.py
@@ -12,7 +12,11 @@ from sklearn.preprocessing import MinMaxScaler
 from scikit_quri.backend import BaseEstimator
 from scikit_quri.circuit import LearningCircuit
 
-from ._qnn_common import GradientEstimatorType, predict_inner, estimate_grad
+from ._qnn_common import (
+    GradientEstimatorType,
+    predict_inner_cached,
+    estimate_grad,
+)
 
 
 def mean_squared_error(y_true: NDArray[np.float64], y_pred: NDArray[np.float64]) -> float:
@@ -82,6 +86,8 @@ class QNNRegressor:
     y_exp_ratio: float = field(default=2.2)
 
     trained_param: Optional[Params] = field(default=None)
+
+    _pred_cache: dict = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not issubclass(type(self.estimator), BaseEstimator):
@@ -245,11 +251,12 @@ class QNNRegressor:
         )
 
     def _predict_inner(self, x_scaled: NDArray[np.float64], params: Params) -> NDArray[np.float64]:
-        return predict_inner(
+        return predict_inner_cached(
             self.ansatz,
             self.estimator,
             self.operator,
             x_scaled,
             params,
             self.y_exp_ratio,
+            self._pred_cache,
         )

--- a/scikit_quri/qnn/regressor.py
+++ b/scikit_quri/qnn/regressor.py
@@ -1,6 +1,6 @@
 # mypy: ignore-errors
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 from numpy.typing import NDArray
@@ -87,7 +87,7 @@ class QNNRegressor:
 
     trained_param: Optional[Params] = field(default=None)
 
-    _pred_cache: dict = field(default_factory=dict)
+    _pred_cache: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not issubclass(type(self.estimator), BaseEstimator):
@@ -165,6 +165,9 @@ class QNNRegressor:
         print("")
 
         self.trained_param = optimizer_state.params
+        # Drop cached training-batch prediction so it doesn't pin the y_pred matrix
+        # for the remainder of the instance's lifetime.
+        self._pred_cache.clear()
         print(f"{optimizer_state.cost=}")
 
     def cost_fn(

--- a/scikit_quri/qsvm/base_qsv.py
+++ b/scikit_quri/qsvm/base_qsv.py
@@ -9,7 +9,7 @@ from quri_parts.core.sampling import ConcurrentSampler
 from sklearn import svm
 
 from scikit_quri.circuit import LearningCircuit
-from scikit_quri.state import overlap_estimator
+from scikit_quri.state import OverlapEstimator
 
 
 class SVMethodType(Enum):
@@ -25,6 +25,7 @@ class BaseQSV:
         self.sv_method_type = sv_method_type
         self.data_circuits: list[QuantumCircuit] = []
         self.n_qubit = circuit.n_qubits
+        self.estimator = None
 
     def fit(
         self,
@@ -49,7 +50,7 @@ class BaseQSV:
         n_x = len(x)
         gram_train = np.zeros((n_x, n_x))
         self.data_circuits = [self._run_circuit(x[i]) for i in range(n_x)]
-        self.estimator = overlap_estimator(sampler, n_shots)
+        self.estimator = OverlapEstimator(sampler, n_shots)
         gram_train = self.estimator.estimate_concurrent(
             self.data_circuits, self.data_circuits
         ).reshape(n_x, n_x)
@@ -71,7 +72,7 @@ class BaseQSV:
             pred: Predicted values of shape (n_samples,).
 
         """
-        if not self.estimator:
+        if self.estimator is None:
             raise ValueError("run fit() before predict")
         n_x = len(xs)
         gram_test = np.zeros((n_x, len(self.data_circuits)))

--- a/scikit_quri/state/__init__.py
+++ b/scikit_quri/state/__init__.py
@@ -1,3 +1,3 @@
-from .overlap_estimator import overlap_estimator
+from .overlap_estimator import OverlapEstimator
 
-__all__ = ["overlap_estimator"]
+__all__ = ["OverlapEstimator"]

--- a/scikit_quri/state/overlap_estimator.py
+++ b/scikit_quri/state/overlap_estimator.py
@@ -78,6 +78,35 @@ class OverlapEstimator:
         n_ket = len(ket_circuits)
         n_bra = len(bra_circuits)
         total = n_ket * n_bra
+
+        # Symmetric case: caller passed the same list for ket and bra
+        # (e.g. Gram matrix construction during fit). Compute only the strict
+        # upper triangle, set the diagonal to 1.0, mirror to the lower triangle.
+        if ket_circuits is bra_circuits and n_ket == n_bra:
+            n = n_ket
+            # Upper-triangle pair indices (i < j)
+            iu, ju = np.triu_indices(n, k=1)
+            n_pairs = iu.size
+            upper = np.empty(n_pairs, dtype=np.float64)
+            for start in range(0, n_pairs, batch_size):
+                end = min(start + batch_size, n_pairs)
+                batch = [
+                    (
+                        self.create_overlap_circuit(
+                            ket_circuits[int(iu[idx])], bra_circuits[int(ju[idx])]
+                        ),
+                        self.n_shots,
+                    )
+                    for idx in range(start, end)
+                ]
+                sampling_counts = self.concurrent_sampler(batch)
+                for k, count in enumerate(sampling_counts):
+                    upper[start + k] = count.get(0, 0) / self.n_shots
+            matrix = np.eye(n, dtype=np.float64)
+            matrix[iu, ju] = upper
+            matrix[ju, iu] = upper
+            return matrix.ravel()
+
         overlaps = np.empty(total, dtype=np.float64)
         for start in range(0, total, batch_size):
             end = min(start + batch_size, total)

--- a/scikit_quri/state/overlap_estimator.py
+++ b/scikit_quri/state/overlap_estimator.py
@@ -5,7 +5,7 @@ from quri_parts.circuit.inverse import inverse_circuit
 from quri_parts.core.sampling import ConcurrentSampler
 
 
-class overlap_estimator:
+class OverlapEstimator:
     """Alternative implementation of quri-parts' overlap estimator."""
 
     def __init__(self, concurrent_sampler: ConcurrentSampler, n_shots: int = 1000):
@@ -17,7 +17,6 @@ class overlap_estimator:
         """
         self.concurrent_sampler = concurrent_sampler
         self.n_shots = n_shots
-        self.cache = {}
 
     def create_overlap_circuit(
         self, ket_circuit: QuantumCircuit, bra_circuit: QuantumCircuit
@@ -59,28 +58,39 @@ class overlap_estimator:
         return p
 
     def estimate_concurrent(
-        self, ket_circuits: list[QuantumCircuit], bra_circuits: list[QuantumCircuit]
+        self,
+        ket_circuits: list[QuantumCircuit],
+        bra_circuits: list[QuantumCircuit],
+        batch_size: int = 100,
     ) -> NDArray[np.float64]:
         """Estimate |⟨ψ_i|ψ_j⟩|² for all combinations of ket and bra circuits.
 
         Args:
             ket_circuits: List of quantum circuits representing ket states.
             bra_circuits: List of quantum circuits representing bra states.
+            batch_size: Number of circuits sent to the sampler at once. Bounds
+                peak memory at O(batch_size) instead of O(n_ket * n_bra).
 
         Returns:
             Flat array of shape (n_ket * n_bra,) containing the squared overlaps
             for all (ket, bra) pairs in row-major order.
         """
-        overlap_circuits = []
         n_ket = len(ket_circuits)
         n_bra = len(bra_circuits)
-        for i in range(n_ket):
-            for j in range(n_bra):
-                overlap_circuits.append(
-                    self.create_overlap_circuit(ket_circuits[i], bra_circuits[j])
+        total = n_ket * n_bra
+        overlaps = np.empty(total, dtype=np.float64)
+        for start in range(0, total, batch_size):
+            end = min(start + batch_size, total)
+            batch = [
+                (
+                    self.create_overlap_circuit(
+                        ket_circuits[idx // n_bra], bra_circuits[idx % n_bra]
+                    ),
+                    self.n_shots,
                 )
-        sampling_counts = self.concurrent_sampler(
-            [(circuit, self.n_shots) for circuit in overlap_circuits]
-        )
-        overlaps = np.array([count.get(0, 0) / self.n_shots for count in sampling_counts])
+                for idx in range(start, end)
+            ]
+            sampling_counts = self.concurrent_sampler(batch)
+            for k, count in enumerate(sampling_counts):
+                overlaps[start + k] = count.get(0, 0) / self.n_shots
         return overlaps


### PR DESCRIPTION
## 概要

scikit_quri 全体のコードレビュー（ultrathink）で見つかったバグ修正・パフォーマンス改善・コードクリーンアップを実施。

## 修正内容

### 🐛 バグ修正（6件）
- **共有パラメータ勾配集約**: qulacsパスで share_with 使用時に勾配が正しく集約されない問題を修正
- **estimator Noneガード**: BaseQSV.predict() の  → 
- **Generation.py**: predict() が self.theta ではなく self.trained_param を使うように修正
- **ラムダクロージャ**: PreDefined.py のループ変数 j のキャプチャ問題（j=j）
- **タイポ**: OqtopusEstimator "matchnumber" → "match number"
- **QKRR.py**: n_iteration パラメータがハードコードされた値で上書きされていた問題

### ⚡ パフォーマンス改善（12件）
- **H2**: regressor.py grad_fn einsum化（Pythonループ→np.einsum）
- **H3**: quantum_state() ループ外巻き上げ
- **H4**: compute_expectations 一括concurrent呼び出し
- **H5**: overlap推定の対称性活用（上三角のみ計算）
- **H6**: agg_map スパース行列化
- **M1**: to_batched_for_gradient fancy indexing化
- **M2**: scaluq gradient numpyベクトル化
- **M3**: convert_parametric_circuit lru_cache化
- **M4**: classifier/regressor predict_innerキャッシュ
- **M5**: kernel_tsne pair毎呼び出し→一括BLAS行列積
- **M6**: generate_bound_params テンプレート事前計算
- **L4**: SimEstimator create_qulacs_vector_concurrent_estimatorキャッシュ

### 🧹 コードクリーンアップ（5件）
- 未使用フィールド削除（classifier.py）
- デッドコード削除（_cost, _create_time_evol_gate, _make_hamiltonian）
- コメントアウト削除
- 重複 preprocess_x 削除
- backprop_innner_product タイポ修正

### 🔧 リファクタリング（4件）
- SimGradientEstimator / OqtopusGradientEstimator estimator一回生成
- overlap_estimator バッチ処理化 + 不要 cache 削除
- overlap_estimator → OverlapEstimator リネーム

## テスト結果
- 18 passed, 7 skipped, 3 failed（3 failures は OQTOPUS Cloud 認証エラーで修正内容に無関係）
- 全QNN/QSVM/QKRRテスト通過