### PR TITLE
refactor(backend): split SimEstimator into Qulacs/Scaluq, add BatchedSimEstimator capability ABC

### DIFF
--- a/samples/sample_dqn_cl.ipynb
+++ b/samples/sample_dqn_cl.ipynb
@@ -66,10 +66,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scikit_quri.backend import SimEstimator\n",
+    "from scikit_quri.backend import QulacsEstimator\n",
     "def create_classifier(n_features: int, circuit: LearningCircuit, locality: int):\n",
     "    adam = Adam()\n",
-    "    estimator = SimEstimator()\n",
+    "    estimator = QulacsEstimator()\n",
     "    gradient_estimator = create_numerical_gradient_estimator(\n",
     "        create_qulacs_vector_concurrent_parametric_estimator(), delta=1e-3,\n",
     "    )\n",

--- a/samples/sample_qcnn.ipynb
+++ b/samples/sample_qcnn.ipynb
@@ -66,10 +66,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scikit_quri.backend import SimEstimator\n",
+    "from scikit_quri.backend import QulacsEstimator\n",
     "num_class = 2  # 分類数（ここでは2つに分類）\n",
     "optimizer = LBFGS()\n",
-    "estimator = SimEstimator()\n",
+    "estimator = QulacsEstimator()\n",
     "gradient_estimator = create_numerical_gradient_estimator(\n",
     "    create_qulacs_vector_concurrent_parametric_estimator(), delta=1e-3\n",
     ")\n",

--- a/samples/sample_qnn_classifier.ipynb
+++ b/samples/sample_qnn_classifier.ipynb
@@ -285,14 +285,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Estimatorの準備\n回路からの出力を数値として取り出すためには、オブザーバブル（観測量）の期待値を計算する必要があります。`quri-parts`では、この期待値計算を行うためのインターフェースとして`Estimator`が用意されています。ここでは、以下の2種類の`Estimator`を定義します。\n\nestimator: 回路の出力（期待値）そのものを計算します。学習時のコスト関数の計算や、学習後の推論に使用します。`scikit-quri`の`SimEstimator`を用いると`quri-parts`の`Estimator` が作られます。`SimEstimator`では`use_scaluq=True`を指定することで、scaluqバックエンドによるバッチ処理が有効になり、期待値計算と勾配推定が高速化されます。\n\ngradient_estimator: パラメータに対する期待値の勾配を計算します。これは、パラメータをどの方向に更新すればよいかを知るため（学習）に必要です。"
+   "source": "## Estimatorの準備\n回路からの出力を数値として取り出すためには、オブザーバブル（観測量）の期待値を計算する必要があります。`quri-parts`では、この期待値計算を行うためのインターフェースとして`Estimator`が用意されています。ここでは、以下の2種類の`Estimator`を定義します。\n\nestimator: 回路の出力（期待値）そのものを計算します。学習時のコスト関数の計算や、学習後の推論に使用します。`scikit-quri`は2種類のシミュレーション用Estimatorを提供します: `QulacsEstimator` (quri-parts-qulacsベース、サンプルごとに評価) と `ScaluqEstimator` (scaluqベース、バッチ評価で高速)。ここでは後者を使用します。\n\ngradient_estimator: パラメータに対する期待値の勾配を計算します。これは、パラメータをどの方向に更新すればよいかを知るため（学習）に必要です。"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from quri_parts.core.estimator.gradient import (\n    create_numerical_gradient_estimator,\n)\nfrom quri_parts.qulacs.estimator import (\n    create_qulacs_vector_concurrent_parametric_estimator,\n)\nfrom scikit_quri.backend import SimEstimator\n\n# use_scaluq=True を指定すると、scaluqバックエンドによるバッチ推定が有効になります\nestimator = SimEstimator(use_scaluq=True)\ngradient_estimator = create_numerical_gradient_estimator(\n    create_qulacs_vector_concurrent_parametric_estimator(), delta=1e-10\n)"
+   "source": "from quri_parts.core.estimator.gradient import (\n    create_numerical_gradient_estimator,\n)\nfrom quri_parts.qulacs.estimator import (\n    create_qulacs_vector_concurrent_parametric_estimator,\n)\nfrom scikit_quri.backend import ScaluqEstimator\n\n# ScaluqEstimator はscaluqバックエンドによるバッチ推定を使用します\nestimator = ScaluqEstimator()\ngradient_estimator = create_numerical_gradient_estimator(\n    create_qulacs_vector_concurrent_parametric_estimator(), delta=1e-10\n)"
   },
   {
    "cell_type": "markdown",

--- a/samples/sample_qnn_regressor.ipynb
+++ b/samples/sample_qnn_regressor.ipynb
@@ -18,7 +18,7 @@
     ")\n",
     "from quri_parts.algo.optimizer import Adam, LBFGS\n",
     "from scikit_quri.circuit.pre_defined import create_qcl_ansatz\n",
-    "from scikit_quri.backend import SimEstimator\n",
+    "from scikit_quri.backend import QulacsEstimator\n",
     "\n",
     "\n",
     "def generate_noisy_sine(x_min, x_max, num_x):\n",
@@ -126,7 +126,7 @@
     "\n",
     "draw_circuit(parametric_circuit.circuit)\n",
     "\n",
-    "estimator = SimEstimator()\n",
+    "estimator = QulacsEstimator()\n",
     "optimizer = LBFGS()\n",
     "gradient_estimator = create_numerical_gradient_estimator(\n",
     "    create_qulacs_vector_concurrent_parametric_estimator(), delta=1e-5)"

--- a/scikit_quri/backend/__init__.py
+++ b/scikit_quri/backend/__init__.py
@@ -1,15 +1,20 @@
-from .base_estimator import BaseEstimator
+from .base_estimator import BaseEstimator, BatchedSimEstimator
 from .oqtopus_estimator import OqtopusEstimator
-from .sim_estimator import SimEstimator
-from .oqtopus_sampler import create_oqtopus_sampler
-from .sim_gradient_estimator import SimGradientEstimator
 from .oqtopus_gradient_estimator import OqtopusGradientEstimator
+from .oqtopus_sampler import create_oqtopus_sampler
+from .qulacs_estimator import QulacsEstimator
+from .scaluq_estimator import ScaluqEstimator
+from .sim_estimator import SimEstimator
+from .sim_gradient_estimator import SimGradientEstimator
 
 __all__ = [
     "BaseEstimator",
+    "BatchedSimEstimator",
     "OqtopusEstimator",
-    "SimEstimator",
-    "create_oqtopus_sampler",
-    "SimGradientEstimator",
     "OqtopusGradientEstimator",
+    "QulacsEstimator",
+    "ScaluqEstimator",
+    "SimEstimator",
+    "SimGradientEstimator",
+    "create_oqtopus_sampler",
 ]

--- a/scikit_quri/backend/base_estimator.py
+++ b/scikit_quri/backend/base_estimator.py
@@ -1,11 +1,11 @@
 from abc import ABCMeta, abstractmethod
-from typing import Sequence, Iterable
+from typing import Iterable, Sequence
 
+import numpy as np
+from numpy.typing import NDArray
+from quri_parts.circuit import ParametricQuantumCircuitProtocol
+from quri_parts.core.estimator import Estimatable, Estimate
 from quri_parts.qulacs import QulacsStateT
-from quri_parts.core.estimator import (
-    Estimatable,
-)
-from quri_parts.core.estimator import Estimate
 
 
 class BaseEstimator(metaclass=ABCMeta):
@@ -29,4 +29,70 @@ class BaseEstimator(metaclass=ABCMeta):
 
         Returns:
             operatorsとstatesの組み合わせに対する期待値のリスト
+        """
+
+
+class BatchedSimEstimator(BaseEstimator, metaclass=ABCMeta):
+    """Capability extension for simulation backends that natively batch
+    expectation-value evaluation over a single parametric circuit with many
+    parameter vectors.
+
+    A ``BatchedSimEstimator`` evaluates M operators against one parametric
+    circuit bound with N parameter vectors (one per input sample) in a single
+    backend call, producing an (M, N) matrix. This is the natural API for
+    state-vector simulators (scaluq, future GPU backends) that amortize
+    circuit setup across the batch.
+
+    Hardware backends (e.g. OQTOPUS) cannot exploit this shape and should not
+    inherit from this class; ``_qnn_common`` dispatches via
+    ``isinstance(estimator, BatchedSimEstimator)``.
+    """
+
+    @abstractmethod
+    def estimate_batched(
+        self,
+        operators: Sequence[Estimatable],
+        circuit: ParametricQuantumCircuitProtocol,
+        params: NDArray[np.float64],
+    ) -> list[list[float]]:
+        """Compute batched expectation values for a parametric circuit.
+
+        Args:
+            operators: List of measurement operators. Length: n_operators.
+            circuit: Parametric quantum circuit (e.g. from
+                ``LearningCircuit.to_batched``).
+            params: Per-sample bound parameter matrix.
+                Shape: ``(n_samples, parameter_count)``.
+
+        Returns:
+            Nested list of shape ``(n_operators, n_samples)`` containing real
+            expectation values.
+        """
+
+    @abstractmethod
+    def estimate_grad_batched(
+        self,
+        operators: Sequence[Estimatable],
+        circuit: ParametricQuantumCircuitProtocol,
+        shifted_params: NDArray[np.float64],
+        n_samples: int,
+        n_learning_params: int,
+        delta: float = 1e-5,
+    ) -> NDArray[np.float64]:
+        """Compute batched numerical gradients via central differences.
+
+        Args:
+            operators: List of measurement operators. Length: n_operators.
+            circuit: Parametric quantum circuit (e.g. from
+                ``LearningCircuit.to_batched_for_gradient``).
+            shifted_params: Shifted-parameter matrix.
+                Shape: ``(n_samples * 2 * n_learning_params, parameter_count)``.
+                Row layout matches ``LearningCircuit.to_batched_for_gradient``.
+            n_samples: Number of input samples.
+            n_learning_params: Number of unique learning parameters.
+            delta: Finite-difference step size.
+
+        Returns:
+            Gradient tensor. Shape:
+            ``(n_samples, n_operators, n_learning_params)``.
         """

--- a/scikit_quri/backend/qulacs_estimator.py
+++ b/scikit_quri/backend/qulacs_estimator.py
@@ -1,0 +1,19 @@
+from quri_parts.qulacs.estimator import create_qulacs_vector_concurrent_estimator
+
+from .base_estimator import BaseEstimator
+
+
+class QulacsEstimator(BaseEstimator):
+    """Expectation-value estimator backed by quri-parts-qulacs.
+
+    Evaluates one operator against one quantum state per call (per-sample
+    semantics, concurrent across the inputs of a single ``estimate`` call).
+    For workloads that re-bind the same parametric circuit across many samples,
+    consider ``ScaluqEstimator`` which natively batches that case.
+    """
+
+    def __init__(self) -> None:
+        self._concurrent_estimator = create_qulacs_vector_concurrent_estimator()
+
+    def estimate(self, operators, states):
+        return self._concurrent_estimator(operators, states)

--- a/scikit_quri/backend/scaluq_estimator.py
+++ b/scikit_quri/backend/scaluq_estimator.py
@@ -1,0 +1,52 @@
+from typing import Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+from quri_parts.circuit import ParametricQuantumCircuitProtocol
+from quri_parts.core.estimator import Estimatable
+from quri_parts.qulacs.estimator import create_qulacs_vector_concurrent_estimator
+
+from quri_parts_scaluq import _backend
+from quri_parts_scaluq.estimator import estimate as scaluq_estimate
+from quri_parts_scaluq.estimator import estimate_numerical_gradient as scaluq_grad
+
+from .base_estimator import BatchedSimEstimator
+
+
+class ScaluqEstimator(BatchedSimEstimator):
+    """Batched expectation-value estimator backed by scaluq.
+
+    The primary API is ``estimate_batched`` / ``estimate_grad_batched``, which
+    evaluate a single parametric circuit topology over many parameter vectors
+    in one backend call. The non-batched ``estimate(operators, states)`` is
+    implemented as a fallback that defers to qulacs; it is provided so that
+    consumers expecting the ``BaseEstimator`` contract still work, but the
+    batched methods are what give scaluq its speedup.
+    """
+
+    def __init__(self) -> None:
+        self._concurrent_estimator = create_qulacs_vector_concurrent_estimator()
+
+    def estimate(self, operators, states):
+        return self._concurrent_estimator(operators, states)
+
+    def estimate_batched(
+        self,
+        operators: Sequence[Estimatable],
+        circuit: ParametricQuantumCircuitProtocol,
+        params: NDArray[np.float64],
+    ) -> list[list[float]]:
+        state = _backend.StateVectorBatched(len(params), circuit.qubit_count)
+        state.set_zero_state()
+        return scaluq_estimate(state, circuit, operators, params)
+
+    def estimate_grad_batched(
+        self,
+        operators: Sequence[Estimatable],
+        circuit: ParametricQuantumCircuitProtocol,
+        shifted_params: NDArray[np.float64],
+        n_samples: int,
+        n_learning_params: int,
+        delta: float = 1e-5,
+    ) -> NDArray[np.float64]:
+        return scaluq_grad(circuit, operators, shifted_params, n_samples, n_learning_params, delta)

--- a/scikit_quri/backend/sim_estimator.py
+++ b/scikit_quri/backend/sim_estimator.py
@@ -1,82 +1,36 @@
+"""Backward-compatible factory for the old ``SimEstimator(use_scaluq=...)`` API.
+
+Prefer constructing :class:`~scikit_quri.backend.QulacsEstimator` or
+:class:`~scikit_quri.backend.ScaluqEstimator` directly. ``SimEstimator`` is
+kept so that existing call sites (tests, samples, downstream code) continue
+to work without modification.
+"""
+
+import warnings
+
 from .base_estimator import BaseEstimator
-
-from quri_parts.qulacs.estimator import create_qulacs_vector_concurrent_estimator
-from quri_parts.circuit import ParametricQuantumCircuitProtocol
-from quri_parts.core.estimator import Estimatable
-from typing import Sequence
-
-import numpy as np
-from numpy.typing import NDArray
-
-from quri_parts_scaluq.estimator import estimate as scaluq_estimate
-from quri_parts_scaluq.estimator import estimate_numerical_gradient as scaluq_grad
-from quri_parts_scaluq import _backend
+from .qulacs_estimator import QulacsEstimator
+from .scaluq_estimator import ScaluqEstimator
 
 
-class SimEstimator(BaseEstimator):
-    """Simulation estimator that computes expectation values using quri-parts-qulacs.
+def SimEstimator(use_scaluq: bool = False) -> BaseEstimator:
+    """Construct a simulation estimator.
 
     Args:
-        use_scaluq: If True, use scaluq batched estimation for predict_inner.
-            Defaults to False.
+        use_scaluq: If True, return a :class:`ScaluqEstimator` (batched scaluq
+            backend). Otherwise return a :class:`QulacsEstimator`
+            (per-sample qulacs backend).
+
+    Returns:
+        Either a ``QulacsEstimator`` or a ``ScaluqEstimator`` depending on
+        ``use_scaluq``.
+
+    .. deprecated::
+        Construct ``QulacsEstimator()`` or ``ScaluqEstimator()`` directly.
     """
-
-    def __init__(self, use_scaluq: bool = False) -> None:
-        self.use_scaluq = use_scaluq
-        self._concurrent_estimator = create_qulacs_vector_concurrent_estimator()
-
-    def estimate(self, operators, states):
-        return self._concurrent_estimator(operators, states)
-
-    def estimate_scaluq_batched(
-        self,
-        operators: Sequence[Estimatable],
-        circuit: ParametricQuantumCircuitProtocol,
-        params: NDArray[np.float64],
-    ) -> list[list[float]]:
-        """Compute batched expectation values using scaluq backend.
-
-        Args:
-            operators: List of measurement operators. Length: n_operators.
-            circuit: Parametric quantum circuit (from LearningCircuit.to_batched).
-            params: Batched parameters. Shape: (n_samples, n_params).
-
-        Returns:
-            List of shape (n_operators, n_samples) containing real expectation values.
-        """
-        n_qubits = circuit.qubit_count
-        state = _backend.StateVectorBatched(len(params), n_qubits)
-        state.set_zero_state()
-        return scaluq_estimate(state, circuit, operators, params)
-
-    def estimate_grad_scaluq_batched(
-        self,
-        operators: Sequence[Estimatable],
-        circuit: ParametricQuantumCircuitProtocol,
-        shifted_params: NDArray[np.float64],
-        n_samples: int,
-        n_learning_params: int,
-        delta: float = 1e-5,
-    ) -> NDArray[np.float64]:
-        """Compute batched numerical gradient using scaluq backend.
-
-        Args:
-            operators: List of measurement operators. Length: n_operators.
-            circuit: Parametric quantum circuit (from LearningCircuit.to_batched_for_gradient).
-            shifted_params: Shifted parameter array.
-                Shape: (n_samples * 2 * n_learning_params, parameter_count).
-            n_samples: Number of input samples.
-            n_learning_params: Number of learning parameters.
-            delta: Finite difference step size.
-
-        Returns:
-            Gradient tensor. Shape: (n_samples, n_operators, n_learning_params).
-        """
-        return scaluq_grad(
-            circuit,
-            operators,
-            shifted_params,
-            n_samples,
-            n_learning_params,
-            delta,
-        )
+    warnings.warn(
+        "SimEstimator is deprecated; use QulacsEstimator() or ScaluqEstimator() directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return ScaluqEstimator() if use_scaluq else QulacsEstimator()

--- a/scikit_quri/qnn/_qnn_common.py
+++ b/scikit_quri/qnn/_qnn_common.py
@@ -16,8 +16,7 @@ from quri_parts.core.state import ParametricCircuitQuantumState, quantum_state
 from quri_parts.qulacs import QulacsStateT
 from typing_extensions import TypeAlias
 
-from scikit_quri.backend import BaseEstimator
-from scikit_quri.backend.sim_estimator import SimEstimator
+from scikit_quri.backend import BaseEstimator, BatchedSimEstimator
 from scikit_quri.circuit import LearningCircuit
 
 GradientEstimatorType: TypeAlias = GradientEstimator[_ParametricStateT]
@@ -108,10 +107,11 @@ def predict_inner(
     Returns:
         Prediction matrix. Shape: (n_samples, n_operators).
     """
-    # Use scaluq batched estimation if enabled
-    if isinstance(estimator, SimEstimator) and estimator.use_scaluq:
+    # Capability dispatch: any backend that natively supports batched
+    # parametric evaluation (currently ScaluqEstimator) takes the fast path.
+    if isinstance(estimator, BatchedSimEstimator):
         circuit, batched_params = ansatz.to_batched(x_scaled, params)
-        results = estimator.estimate_scaluq_batched(operators, circuit, batched_params)
+        results = estimator.estimate_batched(operators, circuit, batched_params)
         # results: (n_operators, n_samples) -> transpose to (n_samples, n_operators)
         res = np.array(results, dtype=np.float64).T
         res *= y_exp_ratio
@@ -197,17 +197,18 @@ def estimate_grad(
         operators: List of measurement operators. Length: n_operators.
         x_scaled: Scaled input data. Shape: (n_samples, n_features).
         params: Learning parameters.
-        estimator: Optional estimator. If SimEstimator with use_scaluq=True, uses scaluq batched path.
-        delta: Finite difference step size for scaluq numerical gradient.
+        estimator: Optional estimator. If it implements BatchedSimEstimator,
+            the batched (e.g. scaluq) numerical-gradient path is taken.
+        delta: Finite difference step size for the batched numerical gradient.
 
     Returns:
         Gradient tensor. Shape: (n_samples, n_operators, n_learning_params).
     """
-    # Use scaluq batched gradient if enabled
-    if isinstance(estimator, SimEstimator) and estimator.use_scaluq:
+    # Capability dispatch: batched-simulation backends take the fast path.
+    if isinstance(estimator, BatchedSimEstimator):
         n_learning = ansatz.learning_params_count
         circuit, shifted_params = ansatz.to_batched_for_gradient(x_scaled, params, delta)
-        return estimator.estimate_grad_scaluq_batched(
+        return estimator.estimate_grad_batched(
             operators,
             circuit,
             shifted_params,

--- a/tests/test_scaluq_estimator.py
+++ b/tests/test_scaluq_estimator.py
@@ -1,0 +1,109 @@
+"""Tests for ScaluqEstimator: capability inheritance, the batched API,
+and behavioral parity with QulacsEstimator on the QNN classifier path.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from quri_parts.algo.optimizer import LBFGS
+from quri_parts.core.estimator.gradient import create_numerical_gradient_estimator
+from quri_parts.qulacs.estimator import create_qulacs_vector_concurrent_parametric_estimator
+from sklearn import datasets
+from sklearn.model_selection import train_test_split
+
+from scikit_quri.backend import (
+    BaseEstimator,
+    BatchedSimEstimator,
+    QulacsEstimator,
+    ScaluqEstimator,
+)
+from scikit_quri.circuit import create_qcl_ansatz
+from scikit_quri.qnn import QNNClassifier
+
+
+def test_capability_hierarchy() -> None:
+    """ScaluqEstimator advertises the BatchedSimEstimator capability; QulacsEstimator does not."""
+    scaluq = ScaluqEstimator()
+    qulacs = QulacsEstimator()
+
+    assert isinstance(scaluq, BaseEstimator)
+    assert isinstance(scaluq, BatchedSimEstimator)
+
+    assert isinstance(qulacs, BaseEstimator)
+    assert not isinstance(qulacs, BatchedSimEstimator)
+
+
+def test_estimate_batched_shape() -> None:
+    """estimate_batched returns (n_operators, n_samples) for an ansatz bound across a batch."""
+    from quri_parts.core.operator import Operator, pauli_label
+
+    n_qubits = 3
+    circuit = create_qcl_ansatz(n_qubits, 2, time_step=0.5, seed=0)
+    n_samples = 4
+    rng = np.random.default_rng(0)
+    x_batch = rng.uniform(-1.0, 1.0, (n_samples, n_qubits))
+    theta = rng.uniform(0, 2 * np.pi, circuit.learning_params_count)
+
+    parametric_circuit, batched_params = circuit.to_batched(x_batch, theta)
+
+    operators = [Operator({pauli_label(f"Z {q}"): 1.0}) for q in range(n_qubits)]
+    estimator = ScaluqEstimator()
+    result = estimator.estimate_batched(operators, parametric_circuit, batched_params)
+    arr = np.asarray(result, dtype=np.float64)
+
+    assert arr.shape == (len(operators), n_samples)
+    # Z expectation values must lie in [-1, 1].
+    assert np.all(arr >= -1.0 - 1e-9) and np.all(arr <= 1.0 + 1e-9)
+
+
+def test_classify_iris_matches_qulacs() -> None:
+    """ScaluqEstimator and QulacsEstimator should produce close predictions on the same QNN.
+
+    Trains two classifiers from the same initial parameters and verifies that their
+    softmax outputs agree within a small tolerance — exercising the batched path
+    end-to-end and confirming behavioral parity with the per-sample path.
+    """
+    iris = datasets.load_iris()
+    df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    x = df.loc[:, ["petal length (cm)", "petal width (cm)"]]
+
+    x_train, x_test, y_train, _ = train_test_split(x, iris.target, test_size=0.25, random_state=0)
+    x_train = x_train.to_numpy()
+    x_test = x_test.to_numpy()
+
+    nqubit = 5
+    circuit = create_qcl_ansatz(nqubit, 2, 0.5, 0)
+    gradient_estimator = create_numerical_gradient_estimator(
+        create_qulacs_vector_concurrent_parametric_estimator(), delta=1e-10
+    )
+
+    init = 2 * np.pi * np.random.default_rng(0).random(circuit.learning_params_count)
+
+    def train(estimator):
+        qcl = QNNClassifier(circuit, 3, estimator, gradient_estimator, LBFGS())
+        qcl.trained_param = init.copy()
+        qcl.fit(x_train, y_train, maxiter=3)
+        return qcl.predict(x_test)
+
+    qulacs_pred = train(QulacsEstimator())
+    scaluq_pred = train(ScaluqEstimator())
+
+    # Numerical agreement: both paths evaluate the same circuit, so probabilities
+    # must agree closely. Tolerance is loose because scaluq and qulacs differ in
+    # floating-point ordering on aggregated sums.
+    np.testing.assert_allclose(qulacs_pred, scaluq_pred, atol=1e-4)
+
+
+def test_sim_estimator_factory_returns_scaluq_with_use_scaluq() -> None:
+    """The deprecated SimEstimator factory must still route use_scaluq=True to ScaluqEstimator."""
+    from scikit_quri.backend import SimEstimator
+
+    with pytest.warns(DeprecationWarning):
+        e = SimEstimator(use_scaluq=True)
+    assert isinstance(e, ScaluqEstimator)
+
+    with pytest.warns(DeprecationWarning):
+        e = SimEstimator()
+    assert isinstance(e, QulacsEstimator)


### PR DESCRIPTION
## 概要

`SimEstimator(use_scaluq: bool)` のフラグベース分岐を、**capability ABC + 1 クラス 1 実行モデル** の構造に置き換えるリファクタ。

### 問題: 現状の非対称な dispatch

```python
# _qnn_common.py 内
if isinstance(estimator, SimEstimator) and estimator.use_scaluq:
    # scaluq batched path
else:
    # qulacs per-sample path
```

- 具象クラス `SimEstimator` + フラグ `use_scaluq` の組み合わせで分岐 → ポリモーフィズム漏れ
- `estimate_scaluq_batched` / `estimate_grad_scaluq_batched` は `BaseEstimator` インターフェイスに無く `SimEstimator` 固有メソッド
- 新規 batched backend (GPU 等) を追加するたびに `_qnn_common.py` の isinstance に else if が増える

### 解決策: Capability ABC で機能を表現

新規追加:

- `BatchedSimEstimator(BaseEstimator, ABC)` — 「同じ parametric circuit を多パラメータ列で batched 評価できる」capability マーカー
  - `estimate_batched(operators, circuit, params) -> list[list[float]]`
  - `estimate_grad_batched(operators, circuit, shifted_params, n_samples, n_learning_params, delta) -> NDArray`
- `QulacsEstimator(BaseEstimator)` — quri-parts-qulacs ベース (per-sample)。旧 `SimEstimator(use_scaluq=False)` に対応
- `ScaluqEstimator(BatchedSimEstimator)` — scaluq batched。旧 `SimEstimator(use_scaluq=True)` に対応

`_qnn_common.py` の dispatch を **capability check** に変更:

```python
if isinstance(estimator, BatchedSimEstimator):
    circuit, batched = ansatz.to_batched(x_scaled, params)
    results = estimator.estimate_batched(operators, circuit, batched)
    ...
else:
    # default per-sample path via BaseEstimator
```

これで:
- 具象クラスではなく **capability** で分岐 → ポリモーフィック
- 新規 batched backend は `BatchedSimEstimator` を継承するだけ
- `_qnn_common.py` は変更不要

### 後方互換性

`SimEstimator` は deprecated factory function として残存:

```python
def SimEstimator(use_scaluq: bool = False) -> BaseEstimator:
    warnings.warn("SimEstimator is deprecated; use QulacsEstimator() or ScaluqEstimator() directly.", DeprecationWarning, stacklevel=2)
    return ScaluqEstimator() if use_scaluq else QulacsEstimator()
```

既存呼び出し (`SimEstimator()`, `SimEstimator(use_scaluq=True)`) は引き続き動作、`DeprecationWarning` 付き。

### 追加テスト (`tests/test_scaluq_estimator.py`)

4 ケース:

1. `test_capability_hierarchy` — `ScaluqEstimator` が `BatchedSimEstimator` を継承、`QulacsEstimator` はしない (`_qnn_common` の dispatch で使う isinstance check の妥当性確認)
2. `test_estimate_batched_shape` — `estimate_batched` が `(n_ops, n_samples)` 形状、Z observable の値域 `[-1, 1]` 検証
3. `test_classify_iris_matches_qulacs` — Iris で同一初期パラメータから `QulacsEstimator` / `ScaluqEstimator` で学習、予測一致 (`atol=1e-4`) を確認 → batched パスの数値正確性を end-to-end で検証
4. `test_sim_estimator_factory_returns_scaluq_with_use_scaluq` — deprecated factory の分岐 + `DeprecationWarning` 確認

### Sample 更新

旧 `SimEstimator` を新クラスに migrate:

- `sample_qnn_regressor.ipynb` / `sample_dqn_cl.ipynb` / `sample_qcnn.ipynb`: `SimEstimator()` → `QulacsEstimator()`
- `sample_qnn_classifier.ipynb`: `SimEstimator(use_scaluq=True)` → `ScaluqEstimator()`。markdown も「2 種類のクラスから選択」に書き換え

## テスト

- [x] `tests/test_scaluq_estimator.py` — 4 新規ケース全 pass
- [x] 全テスト: 20 passed / 7 skipped / 5 deselected (OQTOPUS auth) — 約 90 秒
- [x] 互換性: 既存テスト (`test_qnn_classifier`, `test_qnn_regressor` 等) が無修正で pass
- [x] `ruff format` / `ruff check` clean

## 互換性

- `SimEstimator()` / `SimEstimator(use_scaluq=True)` は引き続き動作 (DeprecationWarning 付き)
- `BaseEstimator` の `estimate(operators, states)` インターフェイスは変更なし
- 旧 `SimEstimator.estimate_scaluq_batched` / `estimate_grad_scaluq_batched` メソッド呼び出しはなくなったが、外部利用は確認できなかったため破壊変更として許容

🤖 Generated with [Claude Code](https://claude.com/claude-code)